### PR TITLE
Adopt original dashboard app URL

### DIFF
--- a/repo.xml
+++ b/repo.xml
@@ -7,7 +7,7 @@
     <license>GNU-LGPL</license>
     <copyright>true</copyright>
     <type>application</type>
-    <target>existdb-dashboard</target>
+    <target>dashboard</target>
     <prepare></prepare>
     <finish/>
     <changelog>


### PR DESCRIPTION
Now that the new dashboard app is ready to replace the old one in 5.x.x

Closes https://github.com/eXist-db/existdb-dashboard/issues/13.